### PR TITLE
Create PPDstainv1

### DIFF
--- a/Software /PPDstainv1
+++ b/Software /PPDstainv1
@@ -1,0 +1,41 @@
+G90
+M106 S0 ; fan speed 0
+M302 S0 ; print without checking temperature 
+G28 ; home all axes
+G1 Z230 F5000 ; move z axis to allow installation of Jar holder and headpiece
+G1 X33 Y169.5 ; move x and y axis to allow placement of Jar holder and headpiece. hovers on position of Jar 1
+M0 ; wait to allow installation of Jar holder and headpiece - wait for user input
+M300 S660 P200 ; play tone to indicate procedure start
+M300 S660 P200
+M300 S660 P200
+G1 X33 Y60 ; move to position of Jar N°8
+G1 Z130 ; dip slide rack
+G4 S1 ; wait for 1 second of incubation in Jar
+G1 Z150 F5000 ; raise slide rack agitation raise
+G1 X33 Y60 ; move to position of Jar N°8
+G1 Z130 ; dip slide rack
+G4 S1 ; wait for 1 second of incubation in Jar
+G1 Z150 F5000 ; raise slide rack agitation raise
+G1 X33 Y60 ; move to position of Jar N°8
+G1 Z130 ; dip slide rack
+G4 S3595 ; wait for 3595 seconds of incubation in Jar
+G1 Z230 F5000 ; raise slide rack
+G1 X86.5 Y60 ; move to position of Jar N¯7
+G1 Z130 ; dip slide rack
+G4 S60 ; wait for 60 seconds of incubation in Jar
+G1 Z230 F5000 ; raise slide rack
+G1 X140 Y60 ; move to position of Jar N¯6
+G1 Z130 ; dip slide rack
+G4 S60 ; wait for 60 seconds of incubation in Jar
+G1 Z230 F5000 ; raise slide rack
+G1 X192 Y60 ; move to position of Jar N¯5
+G1 Z130 ; dip slide rack
+G4 S60 ; wait for 60 seconds of incubation in Jar
+G1 Z230 F5000 ; raise slide rack
+G1 X192 Y169.5 F500 ;move to position of Jar N¯4
+G1 Z130 ; dip slide rack
+G4 S60 ; wait for 60 seconds of incubation in Jar
+G1 Z230 F5000 ; raise slide rack
+M300 S1440 P200 ; play tone to indicate end of procedure
+M300 S660 P250
+M300 S880 P300


### PR DESCRIPTION
g-code for Creality Ender-3 3D printer to Paraphenylenediamine stain 1-um Epoxy resin sections mounted on glass histology slides using HistoEnder headpiece, HistoEnder Jar Holder, Tissue-Tek 24-slide rack, and 5-Tissue Tek stain 'Jars' filled with; filtered 250 mL of 1% Paraphenylenediamine stain in 50% Isopropanol + 50% Methanol (Jar 8, 60 minutes with initial agitation), 250mL- 50% Isopropanol + 50% Methanol rinse in Jars 7, 6, and 5 (3 x 1 minute) and 100% Ethyl Alcohol (Jar 4, 1 minute).  Stain References upon request.